### PR TITLE
Feat/suin 전역 토큰확인 로직 + notFound + 로그인 유저제한 페이지 제한 로직 추가 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,10 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import AppRoutes from "./routes/AppRoutes";
 import "./app.css";
-import MainLayout from "./layouts/MainLayout";
-import HomePage from "./pages/HomePage";
-import LoginPage from "./pages/LoginPage";
-import SignupPage from "./pages/SignupPage";
-import PostPage from "./pages/PostPage";
-import MyPage from "./pages/MyPage";
-import ChatPage from "./pages/ChatPage";
 
 function App() {
   return (
     <div className="web_layout_wrapper">
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/" element={<MainLayout />}>
-            <Route index element={<HomePage />} />
-
-            <Route path="/post/:postId" element={<PostPage />} />
-            <Route path="/chat" element={<ChatPage />} />
-            <Route path="/mypage" element={<MyPage />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <AppRoutes />
     </div>
   );
 }

--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -1,6 +1,13 @@
 import axios from "axios";
+import { getLoggedInUserId } from "../utils/checkUser.js";
+import { EXCLUDED_URLS } from "../constants/excludedUrls";
 
-// 1. Axios 인스턴스 생성
+// URL이 제외 대상인지 체크
+function isExcludedUrl(requestUrl) {
+  if (!requestUrl) return true;
+  return EXCLUDED_URLS.some((urlPrefix) => requestUrl.startsWith(urlPrefix));
+}
+
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 3000,
@@ -8,6 +15,32 @@ const axiosInstance = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const url = config.url ?? "";
+
+    if (isExcludedUrl(url)) {
+      delete config.headers.Authorization;
+      console.log(`🔓 [PUBLIC] ${url} → 토큰 없이 요청`);
+      return config;
+    }
+
+    const userId = getLoggedInUserId();
+
+    if (!userId) {
+      console.warn(`❌ [UNAUTHORIZED] ${url} → 유효하지 않은 토큰`);
+      return config; // Authorization 없이 요청됨 (401 처리됨)
+    }
+
+    const token = localStorage.getItem("token");
+    config.headers.Authorization = `Bearer ${token}`;
+    console.log(`🔐 [AUTHORIZED] ${url} → 로그인 유저(${userId})`);
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
 
 // 2. 요청 인터셉터 (ex. 토큰 추가)
 axiosInstance.interceptors.request.use(

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -43,6 +43,7 @@ export default function ChatInput({ onSubmit, disabled }) {
         <div className="chat_input_box">
           <textarea
             className="chat_input_textarea"
+            style={{ lineHeight: "1.4", overflowY: "auto" }}
             disabled={disabled}
             value={text}
             onChange={handleChange}

--- a/src/components/MainPost.jsx
+++ b/src/components/MainPost.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState } from "react";
 import "./mainPage.css";
 import { useNavigate } from "react-router-dom";
 import likedHeart from "../assets/icons/likedheart.png";
@@ -7,7 +7,6 @@ import comments_icon from "../assets/icons/message.png";
 import { togglePostLike } from "../apis/userApi.js";
 import ReactMarkdown from "react-markdown";
 import { getLoggedInUserId } from "/src/utils/checkUser.js";
-
 
 export default function MainPost({ post }) {
   const navigate = useNavigate();
@@ -31,12 +30,13 @@ export default function MainPost({ post }) {
     navigate(`/post/${postId}`);
   };
 
-  const profileImages = import.meta.glob('../assets/images/profile/*.png', {
+  const profileImages = import.meta.glob("../assets/images/profile/*.png", {
     eager: true,
-    import: 'default'
+    import: "default",
   });
-  const imgSrc = profileImages[`../assets/images/profile/profile_${profileImgCode}.png`];
-  
+  const imgSrc =
+    profileImages[`../assets/images/profile/profile_${profileImgCode}.png`];
+
   const [likesCount, setLikesCount] = useState(initialLikesCount);
   const [likedState, setLikedState] = useState(liked);
   const heartImg = likedState ? likedHeart : unlikedHeart;
@@ -44,18 +44,17 @@ export default function MainPost({ post }) {
   const handleLike = async () => {
     const next = !likedState;
     setLikedState(next);
-    setLikesCount(prev => prev + (next ? 1 : -1));
+    setLikesCount((prev) => prev + (next ? 1 : -1));
     try {
       if (getLoggedInUserId() == null) {
-        if (confirm("로그인하시겠습니까?")) 
-          navigate('/login');
+        if (confirm("로그인하시겠습니까?")) navigate("/login");
         return;
       }
       await togglePostLike(postId, next);
     } catch (error) {
       console.error("좋아요 토글 실패:", error);
       setLikedState(!next);
-      setLikesCount(prev => prev - (next ? 1 : -1));
+      setLikesCount((prev) => prev - (next ? 1 : -1));
     }
   };
 
@@ -70,16 +69,16 @@ export default function MainPost({ post }) {
         </div>
       </div>
 
-      <div className="postTitle" onClick={handleClick}>{title}</div>
+      <div className="postTitle" onClick={handleClick}>
+        {title}
+      </div>
 
-      <div className="post_contnet" onClick={handleClick}><ReactMarkdown>{content}</ReactMarkdown></div>
+      <div className="post_contnet" onClick={handleClick}>
+        <ReactMarkdown>{content}</ReactMarkdown>
+      </div>
 
       <div className="icon_group">
-        <img
-          className="icon_button"
-          onClick={handleLike}
-          src={heartImg}
-        />
+        <img className="icon_button" onClick={handleLike} src={heartImg} />
         <span className="icon_text">{likesCount}</span>
 
         <div

--- a/src/components/chatInput.css
+++ b/src/components/chatInput.css
@@ -15,7 +15,6 @@
 }
 .chat_input_box {
   width: 100%;
-  height: 100px;
   display: flex;
   flex-direction: column;
   border: 1px solid #f0f0f0;
@@ -27,13 +26,26 @@
 
 .chat_input_textarea {
   width: 100%;
-  height: 50px;
+  min-height: 50px;
+  max-height: 200px;
   border: none;
   font-size: 0.875rem;
   box-sizing: border-box;
   resize: none;
-  line-height: 40px;
-  overflow: hidden;
+  line-height: 1.4;
+  overflow-y: auto;
+}
+.chat_input_textarea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat_input_textarea::-webkit-scrollbar-thumb {
+  background-color: #bbb;
+  border-radius: 3px;
+}
+
+.chat_input_textarea::-webkit-scrollbar-track {
+  background-color: transparent;
 }
 .chat_input_textarea:focus {
   outline: none;
@@ -50,14 +62,14 @@
   align-self: flex-end;
 }
 .chat_input_textarea:disabled {
-  color: #fff; /* 글자 색 흰색 */
-  background-color: transparent; /* 또는 #fff */
-  opacity: 1; /* 흐릿하게 보이는 것 방지 */
+  color: #fff;
+  background-color: transparent;
+  opacity: 1;
 }
 
 .chat_input_textarea:disabled::placeholder {
-  color: #fff; /* placeholder도 흰색으로 */
-  opacity: 1; /* 흐림 방지 */
+  color: #fff;
+  opacity: 1;
 }
 .send_icon {
   cursor: pointer;

--- a/src/components/chatSidebar.css
+++ b/src/components/chatSidebar.css
@@ -67,7 +67,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   width: 100%;
-  max-width: 150px;
+  width: 150px;
 }
 
 .sidebar_more {

--- a/src/constants/excludedUrls.js
+++ b/src/constants/excludedUrls.js
@@ -1,0 +1,7 @@
+export const EXCLUDED_URLS = [
+  "/signin",
+  "/signup",
+  "/post/list",
+  "/post/",
+  "/comment/list",
+];

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,0 +1,18 @@
+import { useNavigate } from "react-router-dom";
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ textAlign: "center", marginTop: "100px" }}>
+      <h1>404</h1>
+      <p>죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
+      <button
+        onClick={() => navigate("/")}
+        style={{ marginTop: "20px", padding: "10px 20px" }}
+      >
+        홈으로 이동
+      </button>
+    </div>
+  );
+}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, useRoutes } from "react-router-dom";
+import { routes } from "./RouteConfig";
+
+function RoutesWrapper() {
+  const element = useRoutes(routes);
+  return element;
+}
+
+export default function AppRoutes() {
+  return (
+    <BrowserRouter>
+      <RoutesWrapper />
+    </BrowserRouter>
+  );
+}

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,14 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { getLoggedInUserId } from "../utils/checkUser";
+
+export default function ProtectedRoute({ children }) {
+  const location = useLocation();
+  const userId = getLoggedInUserId();
+  console.log(`🔐 [AUTHORIZED] 로그인이 필요한 유저 접근 `);
+  if (!userId) {
+    alert("로그인이 필요합니다.");
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+}

--- a/src/routes/RouteConfig.jsx
+++ b/src/routes/RouteConfig.jsx
@@ -1,0 +1,43 @@
+import MainLayout from "../layouts/MainLayout";
+import LoginPage from "../pages/LoginPage";
+import SignupPage from "../pages/SignupPage";
+import HomePage from "../pages/HomePage";
+import PostPage from "../pages/PostPage";
+import ChatPage from "../pages/ChatPage";
+import MyPage from "../pages/MyPage";
+import ProtectedRoute from "./ProtectedRoute";
+
+export const routes = [
+  {
+    path: "/login",
+    element: <LoginPage />,
+  },
+  {
+    path: "/signup",
+    element: <SignupPage />,
+  },
+  {
+    path: "/",
+    element: <MainLayout />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "post/:postId", element: <PostPage /> },
+      {
+        path: "chat",
+        element: (
+          <ProtectedRoute>
+            <ChatPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "mypage",
+        element: (
+          <ProtectedRoute>
+            <MyPage />
+          </ProtectedRoute>
+        ),
+      },
+    ],
+  },
+];

--- a/src/routes/RouteConfig.jsx
+++ b/src/routes/RouteConfig.jsx
@@ -40,4 +40,8 @@ export const routes = [
       },
     ],
   },
+  {
+    path: "*",
+    element: <NotFoundPage />,
+  },
 ];

--- a/src/routes/RouteConfig.jsx
+++ b/src/routes/RouteConfig.jsx
@@ -5,6 +5,7 @@ import HomePage from "../pages/HomePage";
 import PostPage from "../pages/PostPage";
 import ChatPage from "../pages/ChatPage";
 import MyPage from "../pages/MyPage";
+import NotFoundPage from "../pages/NotFoundPage";
 import ProtectedRoute from "./ProtectedRoute";
 
 export const routes = [


### PR DESCRIPTION
## 1. axios 인터셉터 토큰 제외대상 필터링 로직 추가 
```js
// URL이 제외 대상인지 체크
function isExcludedUrl(requestUrl) {
  if (!requestUrl) return true;
  return EXCLUDED_URLS.some((urlPrefix) => requestUrl.startsWith(urlPrefix));
}
```
interceptors.request 에서 getLoggedInUserId 확인 후 isExcludedUrl 제외 URL 에게만 토큰 전달로직으로 변경 

## 2.  ProtectedRoute 컴포넌트를 통해 자식 페이지 컴포넌트 접근 제한 로직 구현 
```js
import { Navigate, useLocation } from "react-router-dom";
import { getLoggedInUserId } from "../utils/checkUser";

export default function ProtectedRoute({ children }) {
  const location = useLocation();
  const userId = getLoggedInUserId();
  console.log(`🔐 [AUTHORIZED] 로그인이 필요한 유저 접근 `);
  if (!userId) {
    alert("로그인이 필요합니다.");
    return <Navigate to="/login" replace state={{ from: location }} />;
  }

  return children;
}
```

## 3. 특정 경로 이외 유저가 경로 진입시 NotFound 접속으로 이동 로직 추가 
```js
 {
    path: "*",
    element: <NotFoundPage />,
  },
```



**현재 작업해주신 각페이지의 getLoggedInUserId() 요청은  interceptors.request 요청시에 확인하는 로직으로 구현이 되어있습니다. 
토큰이 필요없는 URL 의 경우 아래의 상수에서 확인을 하고 있으니 혹시 경로가 잘못되신 분들은 말씀 부탁드립니다.** 

```js
export const EXCLUDED_URLS = [
  "/signin",
  "/signup",
  "/post/list",
  "/post/",
  "/comment/list",
];
```
 